### PR TITLE
Add N2 and background speed based masking.

### DIFF
--- a/driver/combine_turbulence.m
+++ b/driver/combine_turbulence.m
@@ -13,10 +13,18 @@ close all;
    do_mask     =  1; % NaN chi estimates using min dTdz, speed thresholds
 
    % set thresholds for masking
+   min_N2 = 1e-6;
    min_dTdz = 1e-4;
    min_spd = 0.05;
+   min_inst_spd = min_spd; % min instantaneous speed past sensor
    mask_dTdz = 'i'; % 'm' for mooring, 'i' for internal
-
+   mask_inst_spd = 1; % estimates are crappy if sensor isn't moving
+                      % enough.
+                      % screws the spectrum calculation...
+   mask_spd = ''; % masking such that background flow flushes
+                  % sensed water volume
+                  % 'm' for mooring, 'p' for pitot,
+                  % '' to choose based on what was used in chi estimate
    avgwindow = 600; % averaging window in seconds
 
    % if you want to restrict the time range that should be combined use the following
@@ -55,6 +63,8 @@ if do_mask
         Tz = Tz_i;
         clear Tz_i;
     end
+
+    mask_spd_initial = mask_spd;
 end
 
 %_____________________find all available chi data______________________
@@ -79,22 +89,53 @@ if(do_combine)
          % find desired time range
          iiTrange = find( chi.time>= time_range(1) & chi.time<= time_range(2) );
 
-         if do_mask & ~exist('full_mask', 'var')
-             % only need to setup mask once
+         if do_mask
              if mask_dTdz == 'i'
                  % choose appropriate internal stratification for sensor
                  Tz.Tz = Tz.(['Tz' ID(7)']);
              end
-             Tzmask = interp1(Tz.time, Tz.Tz, chi.time(iiTrange));
-             percent_mask_dTdz = sum(abs(Tzmask) < min_dTdz)/length(chi.time(iiTrange))*100;
-             percent_mask_spd = sum(chi.spd < min_spd)/length(chi.time(iiTrange))*100;
 
+             Tzmask = interp1(Tz.time, Tz.Tz, chi.time(iiTrange));
+
+             percent_mask_dTdz = sum(abs(Tzmask) < min_dTdz)/length(chi.time(iiTrange))*100;
+             percent_mask_N2 = sum(chi.N2 < min_N2)/length(chi.time(iiTrange))*100;
+             percent_mask_inst_spd = sum(chi.spd(iiTrange) < min_inst_spd)/length(chi.time(iiTrange))*100;
              disp([' dTdz will mask ' num2str(percent_mask_dTdz, '%.2f') ...
                    ' % of estimates'])
+             disp([' N2 will mask ' num2str(percent_mask_N2, '%.2f') ...
+                   ' % of estimates'])
+             disp([' Inst speed will mask ' num2str(percent_mask_inst_spd, '%.2f') ...
+                   ' % of estimates'])
+
+             % speed mask could change depending on estimate
+             if strcmpi(mask_spd_initial, '')
+                 mask_spd = ID(5);
+             end
+
+             if mask_spd == 'm' & ~exist('vel_m', 'var')
+                 load ../input/vel_m.mat
+                 vel = vel_m;
+                 disp('masking using mooring speed');
+             elseif mask_spd == 'p' & ~exist('vel_p', 'var')
+                 load ../input/vel_p.mat
+                 vel = vel_p;
+                 disp('masking using pitot speed');
+             end
+             spdmask = interp1(vel.time, vel.spd, chi.time(iiTrange));
+             percent_mask_spd = sum(spdmask < min_spd)/length(chi.time(iiTrange))*100;
              disp([' speed will mask ' num2str(percent_mask_spd, '%.2f') ...
                    '% of estimates'])
 
-             full_mask = (abs(Tzmask) < min_dTdz) | (chi.spd < min_spd);
+             full_mask = (abs(Tzmask) < min_dTdz) ...
+                 | (chi.N2 < min_N2) ...
+                 | (chi.spd < min_inst_spd) ...
+                 | (spdmask < min_spd);
+         end
+
+         % NaN out some chi estimates based on min_dTz, min_spd
+         if do_mask
+             chi.chi(full_mask) = NaN;
+             chi.mask = chi.mask | ~full_mask;
          end
 
          % get list of all fields to average
@@ -104,10 +145,6 @@ if(do_combine)
             %% average data
             % convert averaging window from seconds to points
             ww =  round(avgwindow/(diff(chi.time(1:2))*3600*24));
-
-            % NaN out some chi estimates based on min_dTz, min_spd
-            chi.chi(full_mask) = NaN;
-            chi.mask = chi.mask | ~full_mask;
 
             for f = 1:length(ff)  % run through all fields in chi
                if ( length(chi.(ff{f})) == length(chi.time) )
@@ -139,6 +176,9 @@ if(do_combine)
    Turb.mask_dTdz = mask_dTdz;
    Turb.min_dTdz = min_dTdz;
    Turb.min_spd = min_spd;
+   Turb.min_inst_spd = min_inst_spd;
+   Turb.min_N2 = min_N2;
+   Turb.mask_spd = mask_spd_initial;
    %---------------------add readme----------------------
    Turb.readme = {...
          '------------------sub-fields--------------------'; ...


### PR DESCRIPTION
1. Rework because stratification mask needs to only be calculated
   once. Unless mooring is not surface-pumped, should mask out based on
   internal dT/dz.

2. Speed criterion is we throw out estimates if background speed < min_spd.
   Assuming that the backwash from instrument moving up/down is
   flushed away if background speed is > min_spd.
   Previously this was done with total instrument speed.
   Can choose either mooring / pitot / whichever-was-used-in-chi-estimate.

3. Also allow for possibility of turning off masking