### PR TITLE
mooring-adcp-vel: learned to use time series of chipod depth.

### DIFF
--- a/software/main_proc/chi_generate_vel_adcp.m
+++ b/software/main_proc/chi_generate_vel_adcp.m
@@ -31,7 +31,7 @@ vel_m.time  = time;
 vel_m.depth = z_chi;
 
 
-if z_adcp == z_chi   % in case it is already interpolated
+if (length(z_chi) == 1) & (z_adcp == z_chi)   % in case it is already interpolated
 
    vel_m.u = u;
    vel_m.v = v;
@@ -51,11 +51,15 @@ else     % in cse it is at a differnt depth interpolate
        v = v';
    end
 
+   if length(z_chi) == 1
+       z_chi = z_chi * ones(size(time));
+   end
+
    % loop through every time step
    for t = 1:length(time)
 
-      vel_m.u(t) = interp1(z_adcp(t,:), u(t,:), z_chi);
-      vel_m.v(t) = interp1(z_adcp(t,:), v(t,:), z_chi);
+      vel_m.u(t) = interp1(z_adcp(t,:), u(t,:), z_chi(t));
+      vel_m.v(t) = interp1(z_adcp(t,:), v(t,:), z_chi(t));
 
    end
 end


### PR DESCRIPTION
My moorings are moving approx. 50m in the vertical!

So I have to be careful when pulling velocities out of adcp record.

Is it enough to be careful about this in `pre_driver.m`?

