### PR TITLE
Speed up all moving_* functions.

### DIFF
--- a/software/additional/moving_average.m
+++ b/software/additional/moving_average.m
@@ -5,18 +5,26 @@ function A = moving_average(v,ww,ws)
 % with the window step (ws)
 %  length(A) = length(v)-ww
 
+if ww == 1 | ww == 0
+    A = v;
+    return;
+end
 N = length(v);
+
+if(N < ww)
+    error('window width is larger than vector length')
+end
 
 A = nan(1,round((N)/ws));
 
-if(N > ww)
+try
+    AA = movmean(v, ww, 'omitnan', 'endpoints', 'discard');
+    AA = AA(1:ws:end);
+    A(1:length(AA)) = AA;
+catch ME
     for i = 1:length(A)
-      if((ww+(i-1)*ws)<=length(v))
-        A(i) = nanmean(v((1:ww)+(i-1)*ws)); 
-      end
+        if((ww+(i-1)*ws)<=length(v))
+            A(i) = nanmean(v((1:ww)+(i-1)*ws));
+        end
     end
-else
-    disp('window width is larger than vector length')
-end
-
 end

--- a/software/additional/moving_median.m
+++ b/software/additional/moving_median.m
@@ -5,18 +5,27 @@ function A = moving_median(v,ww,ws)
 % with the window step (ws)
 %  length(A) = length(v)-ww
 
+
+if ww == 1 | ww == 0
+    A = v;
+    return;
+end
 N = length(v);
+
+if(N < ww)
+    error('window width is larger than vector length')
+end
 
 A = nan(1,round((N)/ws));
 
-if(N > ww)
+try
+    AA = movmedian(v, ww, 'omitnan', 'endpoints', 'discard');
+    AA = AA(1:ws:end);
+    A(1:length(AA)) = AA;
+catch ME
     for i = 1:length(A)
       if((ww+(i-1)*ws)<=length(v))
         A(i) = nanmedian(v((1:ww)+(i-1)*ws)); 
       end
     end
-else
-    disp('window width is larger than vector length')
-end
-
 end

--- a/software/additional/moving_min.m
+++ b/software/additional/moving_min.m
@@ -5,18 +5,28 @@ function A = moving_min(v,ww,ws)
 % with the window step (ws)
 %  length(A) = length(v)-ww
 
+if ww == 1 | ww == 0
+    A = v;
+    return;
+end
 N = length(v);
+
+if(N < ww)
+    error('window width is larger than vector length')
+end
 
 A = nan(1,round((N)/ws));
 
-if(N > ww)
+try
+    AA = movmin(v, ww, 'omitnan', 'endpoints', 'discard');
+    AA = AA(1:ws:end);
+    A(1:length(AA)) = AA;
+catch ME:
     for i = 1:length(A)
       if((ww+(i-1)*ws)<=length(v))
         A(i) = nanmin(v((1:ww)+(i-1)*ws)); 
       end
     end
-else
-    disp('window width is larger than vector length')
 end
 
 end

--- a/software/additional/moving_var.m
+++ b/software/additional/moving_var.m
@@ -5,18 +5,28 @@ function A = moving_var(v,ww,ws)
 % with the window step (ws)
 %  length(A) = length(v)-ww
 
+
+if ww == 1 | ww == 0
+    A = v;
+    return;
+end
 N = length(v);
 
-A = nan(1,round((N)/ws));
+if(N < ww)
+    error('window width is larger than vector length')
+end
 
-if(N > ww)
+A = nan(1,round((N)/ws));
+try
+    AA = movvar(v, ww, 'omitnan', 'endpoints', 'discard');
+    AA = AA(1:ws:end);
+    A(1:length(AA)) = AA;
+catch ME
     for i = 1:length(A)
       if((ww+(i-1)*ws)<=length(v))
         A(i) = nanvar(v((1:ww)+(i-1)*ws)); 
       end
     end
-else
-    disp('window width is larger than vector length')
 end
 
 end


### PR DESCRIPTION
1. If window is of length 1 or 0, short-circuit and return input.
2. Use MATLAB built-in movmedian, movvar, movmin, movmean if possible.

Replicates results of original algorithm.

Haven't done the ones that deal with angles.