### PR TITLE
major changes to combine_turbulence 

### DIFF
--- a/driver/combine_turbulence.m
+++ b/driver/combine_turbulence.m
@@ -153,8 +153,7 @@ if(do_combine)
          chi.Jq = -rho .* cp .* chi.Kt .* chi.dTdz;
 
          if do_plot
-             hfig = figure('Color',[1 1 1],'visible','on', ...
-                           'Position', [100 100 1400 900]);
+             hfig = CreateFigure;
              Histograms(chi, hfig, normstr, 'raw');
          end
 
@@ -179,19 +178,22 @@ if(do_combine)
              if do_plot & exist('../proc/temp.mat', 'file')
                  load ../proc/temp.mat
                  load ../input/vel_m.mat
-                 figure('Color',[1 1 1],'visible','on', 'Position', ...
-                        [100 100 900 900]);
+                 CreateFigure;
 
                  dt = diff(T.time(1:2))*86400;
                  trange = [find_approx(T.time, time_range(1)):find_approx(T.time, time_range(2))];
                  subplot(211)
-                 histogram(T.a_vel_x(trange), 'normalization' ,'pdf');
+                 histogram(T.a_vel_x(trange), 'normalization' ,'pdf', ...
+                           'displaystyle', 'stairs', 'linewidth', 1.5);
                  hold on;
-                 histogram(hypot(T.a_vel_x(trange), T.a_vel_y(trange)), 'normalization' ,'pdf');
-                 histogram(T.a_vel_z(trange), 'normalization' ,'pdf');
+                 histogram(hypot(T.a_vel_x(trange), T.a_vel_y(trange)), ...
+                           'normalization' ,'pdf', 'displaystyle', 'stairs', 'linewidth', 1.5);
+                 histogram(T.a_vel_z(trange), 'normalization' ,'pdf', ...
+                           'displaystyle', 'stairs', 'linewidth', 1.5);
 
                  trange2 = [find_approx(vel_m.time, time_range(1)):find_approx(vel_m.time, time_range(2))];
-                 histogram(vel_m.spd(trange2), 'normalization' ,'pdf')
+                 histogram(vel_m.spd(trange2), 'normalization' ,'pdf', ...
+                           'displaystyle', 'stairs', 'linewidth', 1.5);
                  plot([1 1]*min_spd, ylim, 'k--');
                  set(gca, 'XTick', sort([min_spd get(gca, 'XTick')]));
                  ylim([0 20]); xlim([-0.25 1]*0.7*max(vel_m.spd))
@@ -203,9 +205,10 @@ if(do_combine)
                         num2str(round(dt2)) 'minutes \Deltat for background'])
 
                  subplot(212)
-                 histogram(log10(chi.eps), 'normalization', 'pdf')
+                 histogram(log10(chi.eps), 'normalization', 'pdf', 'displaystyle', 'stairs', 'linewidth', 1.5);
                  hold on;
-                 histogram(log10(chi.eps(spdmask < min_spd)), 'normalization', 'pdf')
+                 histogram(log10(chi.eps(spdmask < min_spd)), ...
+                           'normalization', 'pdf', 'displaystyle', 'stairs', 'linewidth', 1.5);
                  ylabel('PDF')
                  xlabel('log_{10} \epsilon')
                  xlim([-14 5])
@@ -276,7 +279,7 @@ if(do_combine)
          toc(ticstart)
 
          if do_plot
-             hfig2 = figure;
+             hfig2 = CreateFigure;
              Histograms(Turb.(ID), hfig2, normstr, ...
                         ['Final ' num2str(avgwindow/60) ' min mean']);
 
@@ -340,8 +343,9 @@ if do_plot
    ff = fields(Turb);
    ff = {ff{1:end-1}}'; % remove readme structure
 
-    fig = figure('Color',[1 1 1],'visible','on','Paperunits','centimeters',...
-            'Papersize',[30 20],'PaperPosition',[0 0 30 20])
+   fig = CreateFigure;
+    % fig = figure('Color',[1 1 1],'visible','on','Paperunits','centimeters',...
+    %         'Papersize',[30 20],'PaperPosition',[0 0 30 20])
     
          [ax, ~] = create_axes(fig, 4, 1, 0);
       

--- a/driver/combine_turbulence.m
+++ b/driver/combine_turbulence.m
@@ -236,7 +236,17 @@ if(do_combine)
                                  ['Additional Tz_' mask_dTdz]);
              end
 
-             % if do_plot, Histograms(chi, hfig, normstr, 'all masks'); end
+             if do_plot
+                 Histograms(chi, hfig, normstr, 'all masks');
+
+                 figure(hfig)
+                 subplot(221); legend(gca, 'show'); title(ID(5:end));
+                 subplot(222); legend(gca, 'show'); title(ID(5:end));
+                 subplot(223); legend(gca, 'show'); title(ID(5:end));
+                 subplot(224); legend(gca, 'show'); title(ID(5:end));
+
+                 print(gcf,['../pics/histograms-masking-' ID '.png'],'-dpng','-r200','-painters')
+             end
          end
 
          % convert averaging window from seconds to points
@@ -266,16 +276,18 @@ if(do_combine)
          toc(ticstart)
 
          if do_plot
-             Histograms(Turb.(ID), hfig, normstr, ...
+             hfig2 = figure;
+             Histograms(Turb.(ID), hfig2, normstr, ...
                         ['Final ' num2str(avgwindow/60) ' min mean']);
 
-             figure(hfig)
+             figure(hfig2)
              subplot(221); legend(gca, 'show'); title(ID(5:end));
              subplot(222); legend(gca, 'show'); title(ID(5:end));
              subplot(223); legend(gca, 'show'); title(ID(5:end));
              subplot(224); legend(gca, 'show'); title(ID(5:end));
 
-             print(gcf,['../pics/histograms-' ID '.png'],'-dpng','-r200','-painters')
+             print(gcf,['../pics/histograms-final-' ID '.png'],'-dpng','-r200','-painters')
+
          end
       end
    end

--- a/driver/combine_turbulence.m
+++ b/driver/combine_turbulence.m
@@ -103,6 +103,7 @@ if(do_combine)
       if ~isempty(mat_test) & ~isempty(chi_test)
 
          ID = d(i).name(1:mat_test-1);
+         disp(' ');
          disp(['----------> adding ' ID ]);
          load([basedir '/proc/chi/' ID '.mat'])
 
@@ -260,23 +261,26 @@ if(do_combine)
              % calculating Jq and Kt
              % not required for IC estimate because that is already
              % an averaged estimate
+             disp('Deglitch... itch... tch... ch')
+             tic;
              chi.chi = deglitch(chi.chi, ww, 2,'b');
              chi.eps = deglitch(chi.eps, ww, 2, 'b');
-         end
+             toc;
 
-         % get list of all fields to average
-         ff = fields(chi);
+             % get list of all fields to average
+             ff = fields(chi);
 
-         %% average data
-         disp('Running moving average')
-         ticstart = tic;
-         for f = 1:length(ff)  % run through all fields in chi
-             if ff{f}(1) == 'k', continue; end
-             if ( length(chi.(ff{f})) == length(chi.time) )
-                 Turb.(ID).(ff{f}) = moving_average( chi.(ff{f})(iiTrange), ww, ww );
+             %% average data
+             disp('Running moving average')
+             tic;
+             for f = 1:length(ff)  % run through all fields in chi
+                 if ff{f}(1) == 'k', continue; end
+                 if ( length(chi.(ff{f})) == length(chi.time) )
+                     Turb.(ID).(ff{f}) = moving_average( chi.(ff{f})(iiTrange), ww, ww );
+                 end
              end
+             toc
          end
-         toc(ticstart)
 
          if do_plot
              hfig2 = CreateFigure;

--- a/driver/combine_turbulence.m
+++ b/driver/combine_turbulence.m
@@ -17,7 +17,8 @@ close all;
    min_dTdz = 1e-4;
    min_spd = 0.05;
    min_inst_spd = min_spd; % min instantaneous speed past sensor
-   mask_dTdz = 'i'; % 'm' for mooring, 'i' for internal
+   mask_dTdz = ''; % '' for none, 'm' for mooring, 'i' for internal
+                    % in addition to whats in chi.dTdz
    mask_inst_spd = 1; % estimates are crappy if sensor isn't moving
                       % enough.
                       % screws the spectrum calculation...
@@ -28,6 +29,8 @@ close all;
    avgwindow = 600; % averaging window in seconds
 
    ChipodDepth = 30;
+
+   normstr = 'count'; % normalization for histograms
 
    % if you want to restrict the time range that should be combined
    % use the following
@@ -67,16 +70,18 @@ addpath(genpath('./chipod_gust/software/'));% include  path to preocessing routi
 
 if do_mask
     if mask_dTdz == 'm'
-        disp('masking using mooring dTdz')
+        disp('additional masking using mooring dTdz')
         load([basedir 'input/dTdz_m.mat'])
         Tz = Tz_m;
         clear Tz_m;
 
     elseif mask_dTdz == 'i'
-        disp('masking using internal dTdz')
+        disp('additional masking using internal dTdz')
         load([basedir 'input/dTdz_i.mat'])
         Tz = Tz_i;
         clear Tz_i;
+    else
+        Tz = [];
     end
 
     mask_spd_initial = mask_spd;
@@ -117,67 +122,7 @@ if(do_combine)
              cp = sw_cp(Smean, chi.T, ChipodDepth);
          end
 
-         if do_mask
-             if mask_dTdz == 'i'
-                 % choose appropriate internal stratification for sensor
-                 Tz.Tz = Tz.(['Tz' ID(7)']);
-             end
-
-             Tzmask = interp1(Tz.time, Tz.Tz, chi.time);
-
-             percent_mask_dTdz = sum(abs(Tzmask(iiTrange)) < min_dTdz)/length(chi.time(iiTrange))*100;
-             percent_mask_N2 = sum(chi.N2(iiTrange) < min_N2)/length(chi.time(iiTrange))*100;
-             percent_mask_inst_spd = sum(chi.spd(iiTrange) < min_inst_spd)/length(chi.time(iiTrange))*100;
-             disp([' dTdz will mask ' num2str(percent_mask_dTdz, '%.2f') ...
-                   ' % of estimates'])
-             disp([' N2 will mask ' num2str(percent_mask_N2, '%.2f') ...
-                   ' % of estimates'])
-             disp([' Inst speed will mask ' num2str(percent_mask_inst_spd, '%.2f') ...
-                   ' % of estimates'])
-
-             % speed mask could change depending on estimate
-             if strcmpi(mask_spd_initial, '')
-                 mask_spd = ID(5);
-             end
-
-             if mask_spd == 'm' & ~exist('vel_m', 'var')
-                 load ../input/vel_m.mat
-                 vel = vel_m;
-                 disp('masking using mooring speed');
-             elseif mask_spd == 'p' & ~exist('vel_p', 'var')
-                 load ../input/vel_p.mat
-                 vel = vel_p;
-                 disp('masking using pitot speed');
-             end
-             spdmask = interp1(vel.time, vel.spd, chi.time);
-             percent_mask_spd = sum(spdmask(iiTrange) < min_spd)/length(chi.time(iiTrange))*100;
-             disp([' speed will mask ' num2str(percent_mask_spd, '%.2f') ...
-                   '% of estimates'])
-
-             full_mask = (abs(Tzmask) < min_dTdz) ...
-                 | (chi.N2 < min_N2) ...
-                 | (chi.spd < min_inst_spd) ...
-                 | (spdmask < min_spd);
-         end
-
-         % NaN out some chi estimates based on min_dTz, min_spd
-         if do_mask
-             chi.chi(full_mask) = NaN;
-             chi.mask = chi.mask | ~full_mask;
-         end
-
-         % convert averaging window from seconds to points
-         ww =  round(avgwindow/(diff(chi.time(1:2))*3600*24));
-
-         if isempty(ic_test)
-             % deglitch chi and eps before
-             % calculating Jq and Kt
-             % not required for IC estimate because that is already
-             % an averaged estimate
-             chi.chi = deglitch(chi.chi, ww, 2,'b');
-             chi.eps = deglitch(chi.eps, ww, 2, 'b');
-         end
-
+         % NaN out after sensor death
          if isChipod
              if ID(end) == '1' % sensor T1
                  death = find(chi.time > T1death, 1, 'first');
@@ -201,15 +146,90 @@ if(do_combine)
          chi.Kt = 0.5 * chi.chi ./ chi.dTdz.^2;
          chi.Jq = -rho .* cp .* chi.Kt .* chi.dTdz;
 
+         if do_plot
+             hfig = figure('Color',[1 1 1],'visible','on', ...
+                           'Position', [100 100 1400 900]);
+             Histograms(chi, hfig, normstr, 'raw');
+         end
+
+         if do_mask
+             % speed mask could change depending on estimate
+             if strcmpi(mask_spd_initial, '')
+                 mask_spd = ID(5);
+             end
+
+             if mask_spd == 'm' & ~exist('vel_m', 'var')
+                 load ../input/vel_m.mat
+                 vel = vel_m;
+                 disp('masking using mooring speed');
+             elseif mask_spd == 'p' & ~exist('vel_p', 'var')
+                 load ../input/vel_p.mat
+                 vel = vel_p;
+                 disp('masking using pitot speed');
+             end
+             spdmask = interp1(vel.time, vel.spd, chi.time);
+
+             chi = ApplyMask(chi, abs(chi.dTdz), '<', min_dTdz, 'Tz', iiTrange);
+             if do_plot, Histograms(chi, hfig, normstr, 'Tz'); end
+
+             chi = ApplyMask(chi, chi.N2, '<', min_N2, 'N2', iiTrange);
+             if do_plot, Histograms(chi, hfig, normstr, 'N2'); end
+
+             chi = ApplyMask(chi, chi.spd, '<', min_inst_spd, 'inst speed', iiTrange);
+             chi = ApplyMask(chi, spdmask, '<', min_spd, 'background flow', iiTrange);
+
+             % additional Tz masking?
+             if ~isempty(Tz)
+                 if mask_dTdz == 'i'
+                     % choose appropriate internal stratification for sensor
+                     Tz.Tz = Tz.(['Tz' ID(7)']);
+                 end
+
+                 Tzmask = interp1(Tz.time, Tz.Tz, chi.time);
+                 chi = ApplyMask(chi, abs(Tzmask), '<', 1e-4, ...
+                                 ['Additional Tz_' mask_dTdz], iiTrange);
+             end
+
+             % if do_plot, Histograms(chi, hfig, normstr, 'all masks'); end
+         end
+
+         % convert averaging window from seconds to points
+         ww =  round(avgwindow/(diff(chi.time(1:2))*3600*24));
+
+         if isempty(ic_test)
+             % deglitch chi and eps before
+             % calculating Jq and Kt
+             % not required for IC estimate because that is already
+             % an averaged estimate
+             chi.chi = deglitch(chi.chi, ww, 2,'b');
+             chi.eps = deglitch(chi.eps, ww, 2, 'b');
+         end
+
          % get list of all fields to average
          ff = fields(chi);
 
          %% average data
          disp('Running moving average')
+         ticstart = tic;
          for f = 1:length(ff)  % run through all fields in chi
+             if ff{f}(1) == 'k', continue; end
              if ( length(chi.(ff{f})) == length(chi.time) )
                  Turb.(ID).(ff{f}) = moving_average( chi.(ff{f})(iiTrange), ww, ww );
              end
+         end
+         toc(ticstart)
+
+         if do_plot
+             Histograms(Turb.(ID), hfig, normstr, ...
+                        ['Final ' num2str(avgwindow/60) ' min mean']);
+
+             figure(hfig)
+             subplot(221); legend(gca, 'show'); title(ID(5:end));
+             subplot(222); legend(gca, 'show'); title(ID(5:end));
+             subplot(223); legend(gca, 'show'); title(ID(5:end));
+             subplot(224); legend(gca, 'show'); title(ID(5:end));
+
+             print(gcf,['../pics/histograms-' ID '.png'],'-dpng','-r200','-painters')
          end
       end
    end

--- a/driver/combine_turbulence.m
+++ b/driver/combine_turbulence.m
@@ -274,12 +274,13 @@ if(do_combine)
              disp('Running moving average')
              tic;
              for f = 1:length(ff)  % run through all fields in chi
-                 if ff{f}(1) == 'k', continue; end
                  if ( length(chi.(ff{f})) == length(chi.time) )
                      Turb.(ID).(ff{f}) = moving_average( chi.(ff{f})(iiTrange), ww, ww );
                  end
              end
-             toc
+             toc;
+         else
+             Turb.(ID) = chi;
          end
 
          if do_plot

--- a/driver/combine_turbulence.m
+++ b/driver/combine_turbulence.m
@@ -27,6 +27,7 @@ close all;
                   % '' to choose based on what was used in chi estimate
    avgwindow = 600; % averaging window in seconds
 
+   ChipodDepth = 30;
 
    % if you want to restrict the time range that should be combined
    % use the following
@@ -99,21 +100,18 @@ if(do_combine)
          ID = d(i).name(1:mat_test-1);
          disp(['----------> adding ' ID ]);
          load([basedir '/proc/chi/' ID '.mat'])
-         
-         % find desired time range
-         iiTrange = find( chi.time>= time_range(1) & chi.time<= time_range(2) );
 
-         ChipodDepth = round(nanmean(chi.depth(iiTrange))); % in metres
+         % find desired time range
+         iiTrange = find( chi.time >= time_range(1) & chi.time<= time_range(2) );
 
          % read in mooring salinity & calculate rho, cp
          if ~exist('Smean', 'var')
              try
                  load ../proc/T_m.mat
-                 Smean = (T1.S .* abs(nanmean(T2.z)-ChipodDepth) ...
-                          + T2.S .* abs(nanmean(T1.z)-ChipodDepth)) ...
-                         ./ abs(nanmean(T1.z)-nanmean(T2.z));
-                 Smean = interp1(T1.time, Smean, chi.time);
+                 Smean = interp1(T1.time, (T1.S + T2.S)/2, chi.time);
                  chi.S = Smean;
+             catch ME
+                 Smean = 35*ones(size(chi.time));
              end
              rho = sw_pden(Smean, chi.T, ChipodDepth, 0);
              cp = sw_cp(Smean, chi.T, ChipodDepth);

--- a/driver/combine_turbulence.m
+++ b/driver/combine_turbulence.m
@@ -169,6 +169,46 @@ if(do_combine)
              end
              spdmask = interp1(vel.time, vel.spd, chi.time);
 
+             % histograms for speed-based masking
+             if do_plot & exist('../proc/temp.mat', 'file')
+                 load ../proc/temp.mat
+                 load ../input/vel_m.mat
+                 figure('Color',[1 1 1],'visible','on', 'Position', ...
+                        [100 100 900 900]);
+
+                 dt = diff(T.time(1:2))*86400;
+                 trange = [find_approx(T.time, time_range(1)):find_approx(T.time, time_range(2))];
+                 subplot(211)
+                 histogram(T.a_vel_x(trange), 'normalization' ,'pdf');
+                 hold on;
+                 histogram(hypot(T.a_vel_x(trange), T.a_vel_y(trange)), 'normalization' ,'pdf');
+                 histogram(T.a_vel_z(trange), 'normalization' ,'pdf');
+
+                 trange2 = [find_approx(vel_m.time, time_range(1)):find_approx(vel_m.time, time_range(2))];
+                 histogram(vel_m.spd(trange2), 'normalization' ,'pdf')
+                 plot([1 1]*min_spd, ylim, 'k--');
+                 set(gca, 'XTick', sort([min_spd get(gca, 'XTick')]));
+                 ylim([0 20]); xlim([-0.25 1]*0.7*max(vel_m.spd))
+                 xlabel('m/s')
+                 ylabel('PDF')
+                 legend('v_x', '|v_x + v_y|', 'v_z', 'background flow', 'min. spd criterion');
+                 dt2 = diff(vel_m.time(1:2))*86400/60;
+                 title([ID(5:end) ' | ' num2str(round(dt)) 's avg for v_* | ' ...
+                        num2str(round(dt2)) 'minutes \Deltat for background'])
+
+                 subplot(212)
+                 histogram(log10(chi.eps(iiTrange)), 'normalization', 'pdf')
+                 hold on;
+                 histogram(log10(chi.eps(spdmask(iiTrange) < min_spd)), 'normalization', 'pdf')
+                 ylabel('PDF')
+                 xlabel('log_{10} \epsilon')
+                 xlim([-14 5])
+                 legend('raw', ['background flow < ' num2str(min_spd) 'm/s']);
+
+                 print(gcf,['../pics/velocity-masking-' ID(5:end) '.png'],'-dpng','-r200','-painters')
+             end
+
+
              chi = ApplyMask(chi, abs(chi.dTdz), '<', min_dTdz, 'Tz', iiTrange);
              if do_plot, Histograms(chi, hfig, normstr, 'Tz'); end
 

--- a/driver/combine_turbulence.m
+++ b/driver/combine_turbulence.m
@@ -389,3 +389,12 @@ if do_plot
    print(gcf,'../pics/Compare_Turb.png','-dpng','-r200','-painters')
    
 end
+
+
+% Examples of using TestMask and DebugPlots to check masking
+% TestMask(chi, abs(chi.dTdz), '<', [1e-4, 3e-4, 1e-3], 'Tz', iiTrange);
+% t0 = datenum(2014, 01, 01);
+% t1 = datenum(2014, 03, 01);
+% DebugPlots([], t0, t1, chi, 'raw', 1)
+% chi1 = ApplyMask(chi, abs(chi.dTdz), '<', 3e-4, 'T_z', iiTrange);
+% DebugPlots([], t0, t1, chi1, 'T_z > 3e-4', 1)

--- a/software/additional/ApplyMask.m
+++ b/software/additional/ApplyMask.m
@@ -1,0 +1,22 @@
+function [chi] = ApplyMask(chi, maskvar, relation, criterion, maskname, Trange)
+    if relation == '>'
+        mask = maskvar > criterion;
+    elseif relation == '<'
+        mask = maskvar < criterion;
+    end
+
+    numnans = sum(isnan(chi.chi(Trange)));
+    chi.chi(mask) = nan;
+    chi.eps(mask) = nan;
+    chi.Kt(mask) = nan;
+    chi.Jq(mask) = nan;
+    chi.mask = isnan(chi.chi);
+
+    numnewnans = sum(isnan(chi.chi(Trange)));
+
+    disp([maskname ' ' relation ' ' num2str(criterion, '%1.1e') ...
+          ' NaN-ed out ' num2str((numnewnans-numnans)/ ...
+                                 length(chi.chi(Trange))*100, '%.2f') ...
+          '% of estimates'])
+
+end

--- a/software/additional/ApplyMask.m
+++ b/software/additional/ApplyMask.m
@@ -1,4 +1,6 @@
 function [chi] = ApplyMask(chi, maskvar, relation, criterion, maskname, Trange)
+
+    if ~exist('Trange', 'var'), Trange = 1:length(chi.chi); end
     if relation == '>'
         mask = maskvar > criterion;
     elseif relation == '<'

--- a/software/additional/CreateFigure.m
+++ b/software/additional/CreateFigure.m
@@ -1,0 +1,14 @@
+function [hfig] = CreateFigure()
+
+    hfig = figure('Color',[1 1 1],'visible','on', ...
+                  'Position', [100 100 1400 900]);
+
+    set(hfig, 'DefaultAxesFontSize', 18);
+    set(hfig, 'renderer', 'painters');
+
+    set(hfig,'DefaultAxesBox','on')
+    set(hfig,'DefaultAxesTickDir','out')
+
+    set(hfig, 'DefaultHistogramEdgeColor', 'none');
+
+end

--- a/software/additional/Histograms.m
+++ b/software/additional/Histograms.m
@@ -1,0 +1,37 @@
+function Histograms(chi, hfig, normstr, legstr)
+
+    subplot(221);
+    set(gca, 'color', 'none')
+    myhist(chi.chi, normstr, legstr)
+    hold on;
+    xlabel('log_{10} \chi')
+    ylabel(normstr)
+
+    subplot(222);
+    set(gca, 'color', 'none')
+    myhist(chi.eps, normstr, legstr)
+    xlabel('log_{10} \epsilon')
+    ylabel(normstr)
+    hold on;
+
+    subplot(223)
+    set(gca, 'color', 'none')
+    myhist(chi.Kt, normstr, legstr)
+    hold on;
+    xlabel('log_{10} K_T')
+    ylabel(normstr)
+
+    subplot(224)
+    set(gca, 'color', 'none')
+    myhist(abs(chi.Jq), normstr, legstr)
+    hold on;
+    xlabel('log_{10} |J_q|')
+    ylabel(normstr)
+end
+
+function myhist(var, normstr, legstr)
+    histogram(log10(var), 'normalization', normstr, ...
+              'binmethod', 'sqrt', 'displayname', legstr, ...
+              'edgecolor', 'none', 'facealpha', 0.4, ...
+              'displaystyle', 'stairs')
+end

--- a/software/additional/Histograms.m
+++ b/software/additional/Histograms.m
@@ -1,5 +1,7 @@
 function Histograms(chi, hfig, normstr, legstr)
 
+    figure(hfig)
+
     subplot(221);
     set(gca, 'color', 'none')
     myhist(chi.chi, normstr, legstr)
@@ -32,6 +34,5 @@ end
 function myhist(var, normstr, legstr)
     histogram(log10(var), 'normalization', normstr, ...
               'binmethod', 'sqrt', 'displayname', legstr, ...
-              'edgecolor', 'none', 'facealpha', 0.4, ...
-              'displaystyle', 'stairs')
+              'displaystyle', 'stairs', 'LineWidth', 1.5)
 end

--- a/software/mix_files/DebugPlots.m
+++ b/software/mix_files/DebugPlots.m
@@ -1,0 +1,61 @@
+function [] = DebugPlots(hfig, t0, t1, chi, name, ww)
+
+    if ~exist('ww', 'var'), ww = 1; end
+    if isempty(hfig), hfig = gcf(); end
+
+    i0 = find_approx(chi.time, t0, 1);
+    i1 = find_approx(chi.time, t1, 1);
+    tind = i0:i1;
+
+    figure(hfig);
+    ax(1) = subplot(511);
+    semilogy(chi.time(tind), chi.N2(tind)./chi.dTdz(tind).^2, 'displayname', name)
+    ylabel('N^2/T_z^2')
+    Common()
+
+    ax(2) = subplot(512);
+    plot(chi.time(tind), chi.dTdz(tind), 'displayname', name)
+    hold on;
+    plot(xlim, [0, 0], 'k--');
+    ylabel('dT/dz')
+    Common()
+
+    ax(3) = subplot(513);
+    try
+        semilogy(chi.time(tind), chi.eps(tind), 'displayname', name)
+    catch ME
+        semilogy(chi.time(tind), chi.eps1(tind), 'displayname', name)
+    end
+    ylabel('\epsilon')
+    Common()
+
+    ax(4) = subplot(514);
+    try
+        semilogy(chi.time(tind), chi.Kt(tind), 'displayname', name)
+    catch ME
+        semilogy(chi.time(tind), chi.Kt1(tind), 'displayname', name)
+    end
+    ylabel('K_t')
+    Common()
+
+    ax(5) = subplot(515);
+    try
+        plot(moving_average(chi.time(tind), ww, ww), ...
+             moving_average(chi.Jq(tind), ww, ww), 'displayname', name)
+    catch ME
+        plot(moving_average(chi.time(tind), ww, ww), ...
+             moving_average(-chi.Jq1(tind), ww, ww), 'displayname', name)
+    end
+    ylabel('J_q^t')
+    Common()
+    legend('-DynamicLegend');
+
+    linkaxes(ax, 'x')
+    xlim([t0, t1])
+    datetick('x', 'mmm-dd HH:MM', 'keeplimits')
+end
+
+function Common()
+    hold on
+    datetick('x', 'mm-dd HH:MM', 'keeplimits')
+end

--- a/software/mix_files/TestMask.m
+++ b/software/mix_files/TestMask.m
@@ -1,0 +1,17 @@
+function [] = TestMask(chi, mask_var, mask_sign, mask_vals, name, iiTrange)
+
+    hfig = figure;
+    chiold = chi;
+    Histograms(chi, hfig, 'count', 'raw');
+    for ii=1:length(mask_vals)
+        chi = ApplyMask(chi, mask_var, mask_sign, mask_vals(ii), ...
+                        name, iiTrange);
+        if mask_sign == '>'
+            label = [name ' < ' num2str(mask_vals(ii), '%.1e')];
+        else
+            label = [name ' > ' num2str(mask_vals(ii), '%.1e')];
+        end
+        Histograms(chi, hfig, 'count', label);
+
+        chi = chiold; % reset
+    end


### PR DESCRIPTION
1. Automatically make histograms showing effect of different masking criteria. Added general functions `Histograms.m` and `ApplyMask.m` to do this neatly.
2. Added `DebugPlots.m` and `TestMask.m` so we can test out effect of different masking values.
3. If `temp.mat` exists, makes a plot showing range of velocities from accelerometer and the background velocity from `vel_m.mat`.

I've tested this out locally and on the MATLAB server. Seems to work fine.

Also tested with `ic` estimate.

Please test with one of your instruments so that we can be sure there aren't any bugs.