### PR TITLE
Proper fix for CTD depths in chi_generate_dTdz_m.m

### DIFF
--- a/software/main_proc/chi_generate_dTdz_m.m
+++ b/software/main_proc/chi_generate_dTdz_m.m
@@ -92,11 +92,15 @@ picdir   =  [sdir '../pics/'];
    Tz_m.Sz = (S1_int-S2_int)/dz;
 
    if ~use_TS_relation
-       if length(z1) == 1
+       if length(z1) ~= 1
            z1_int = interp1(t1, z1, time);
+       else
+           z1_int = z1
        end
-       if length(z2) == 1
+       if length(z2) ~= 1
            z2_int = interp1(t2, z2, time);
+       else
+           z2_int = z2
        end
 
        % cal density


### PR DESCRIPTION
Sally, I think this is the right fix.


When CTD depths are function of time interpolate to the final
time grid.
When CTD depths are a scalar, just use that. This assignment
statement was missing → this was the bug.